### PR TITLE
fix missing runtime-dependencies

### DIFF
--- a/android-beans/build.gradle.kts
+++ b/android-beans/build.gradle.kts
@@ -94,6 +94,14 @@ publishing {
                     dependencyNode.appendNode("groupId", this.group)
                     dependencyNode.appendNode("artifactId", this.name)
                     dependencyNode.appendNode("version", this.version)
+                    dependencyNode.appendNode("scope", "compile")
+                }
+                configurations.getByName("implementation").allDependencies.configureEach {
+                    val dependencyNode = dependenciesNode.appendNode("dependency")
+                    dependencyNode.appendNode("groupId", this.group)
+                    dependencyNode.appendNode("artifactId", this.name)
+                    dependencyNode.appendNode("version", this.version)
+                    dependencyNode.appendNode("scope", "runtime")
                 }
             }
 


### PR DESCRIPTION
add missing implementation-dependencies as runtime-dependencies for client-projects to the generated pom.xml.