### PR TITLE
Kotlin and Java BeanConfigurations

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -39,11 +39,11 @@ Now you're ready to define your beans as described in the following section.
 
 ## Defining beans
 
-To define beans write a class that extends `BeanConfiguration`. The most convenient way is to extend its subclass
-`DeclarativeBeanConfiguration`. In its `beans()`-method you can define your beans in a declarative fashion with the
-various `bean()`-methods:
+To define beans write an object or a class that extends `BeanConfiguration`. The most convenient way is to extend its
+subclass `DeclarativeBeanConfiguration`. In its `beans()`-method you can define your beans in a declarative fashion with
+the various `bean()`-methods:
 ```kotlin
-class MyBeanConfiguration : DeclarativeBeanConfiguration() {
+object MyBeanConfiguration : DeclarativeBeanConfiguration() {
     override fun beans() {
         bean { MyBean() } // with a generated name
         bean("myNamedBean") { MyBean() } // with an explicit name

--- a/android-beans/src/main/kotlin/rocks/frieler/android/beans/BeanConfiguration.kt
+++ b/android-beans/src/main/kotlin/rocks/frieler/android/beans/BeanConfiguration.kt
@@ -8,8 +8,8 @@ import kotlin.reflect.KClass
  * Abstract super-class to define beans for the context of an application.
  *
  *
- * [BeanConfiguration]s must provide a public constructor, which takes the [android.content.Context]
- * or no arguments, to be instantiated.
+ * [BeanConfiguration]s can be defined as an object or must provide a public constructor, which
+ * takes the [android.content.Context] or no arguments, to be instantiated.
  *
  *
  * @author Christopher Frieler

--- a/android-beans/src/test/java/rocks/frieler/android/beans/BeanConfigurationsAssetScannerJavaApiTest.java
+++ b/android-beans/src/test/java/rocks/frieler/android/beans/BeanConfigurationsAssetScannerJavaApiTest.java
@@ -1,0 +1,72 @@
+package rocks.frieler.android.beans;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BeanConfigurationsAssetScannerJavaApiTest {
+	@Mock
+	private Context context;
+	@InjectMocks
+	private BeanConfigurationsAssetScanner beanConfigurationsAssetScanner;
+
+	@Mock
+	private AssetManager assetManager;
+
+	@Test
+	public void canInstantiateAJavaBeanConfiguration() throws IOException {
+		when(assetManager.list(BeanConfigurationsAssetScanner.BEAN_CONFIGURATIONS_ASSET_PATH)).thenReturn(new String[] { "beans.txt" });
+		when(assetManager.open(BeanConfigurationsAssetScanner.BEAN_CONFIGURATIONS_ASSET_PATH + "/beans.txt"))
+				.thenReturn(new ByteArrayInputStream(("rocks.frieler.android.beans.BeanConfigurationsAssetScannerJavaApiTest$AJavaBeanConfiguration\n").getBytes()));
+
+		List<BeanConfiguration> beanConfigurations = new BeanConfigurationsAssetScanner(context).scan(assetManager);
+
+		assertThat(beanConfigurations, hasItem(instanceOf(AJavaBeanConfiguration.class)));
+	}
+
+	public static class AJavaBeanConfiguration extends BeanConfiguration {
+		@NotNull
+		@Override
+		public List<BeanDefinition<?>> getBeanDefinitions() {
+			return Collections.emptyList();
+		}
+	}
+
+	@Test
+	public void canInstantiateAJavaBeanConfigurationNeedingTheContext() throws IOException {
+		when(assetManager.list(BeanConfigurationsAssetScanner.BEAN_CONFIGURATIONS_ASSET_PATH)).thenReturn(new String[] { "beans.txt" });
+		when(assetManager.open(BeanConfigurationsAssetScanner.BEAN_CONFIGURATIONS_ASSET_PATH + "/beans.txt"))
+				.thenReturn(new ByteArrayInputStream(("rocks.frieler.android.beans.BeanConfigurationsAssetScannerJavaApiTest$AJavaBeanConfigurationNeedingTheContext\n").getBytes()));
+
+		List<BeanConfiguration> beanConfigurations = new BeanConfigurationsAssetScanner(context).scan(assetManager);
+
+		assertThat(beanConfigurations, hasItem(instanceOf(AJavaBeanConfigurationNeedingTheContext.class)));
+	}
+
+	public static class AJavaBeanConfigurationNeedingTheContext extends BeanConfiguration {
+		public AJavaBeanConfigurationNeedingTheContext(Context context) {}
+
+		@NotNull
+		@Override
+		public List<BeanDefinition<?>> getBeanDefinitions() {
+			return Collections.emptyList();
+		}
+	}
+}

--- a/android-beans/src/test/kotlin/rocks/frieler/android/beans/BeanConfigurationsAssetScannerTest.kt
+++ b/android-beans/src/test/kotlin/rocks/frieler/android/beans/BeanConfigurationsAssetScannerTest.kt
@@ -3,6 +3,7 @@ package rocks.frieler.android.beans
 import android.content.Context
 import android.content.res.AssetManager
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.hasSize
 import assertk.assertions.isInstanceOf
 import com.nhaarman.mockitokotlin2.mock
@@ -32,6 +33,17 @@ class BeanConfigurationsAssetScannerTest {
 		assertThat(beanConfigurations[0]).isInstanceOf(ABeanConfiguration::class.java)
 		assertThat(beanConfigurations[1]).isInstanceOf(ABeanConfigurationNeedingTheContext::class.java)
 		assertThat(beanConfigurations[2]).isInstanceOf(AnotherBeanConfiguration::class.java)
+	}
+
+	@Test
+	fun `scan() can use a BeanConfiguration defined as object`() {
+		whenever(assets.list(BeanConfigurationsAssetScanner.BEAN_CONFIGURATIONS_ASSET_PATH)).thenReturn(arrayOf("beans.txt"))
+		whenever(assets.open(BeanConfigurationsAssetScanner.BEAN_CONFIGURATIONS_ASSET_PATH + "/beans.txt"))
+				.thenReturn(ByteArrayInputStream(("rocks.frieler.android.beans.BeanConfigurationsAssetScannerTest\$ABeanConfigurationObject\n").toByteArray()))
+
+		val beanConfigurations = beanConfigurationsAssetScanner.scan(assets)
+
+		assertThat(beanConfigurations).contains(ABeanConfigurationObject)
 	}
 
 	@Test(expected = BeanInstantiationException::class)
@@ -73,13 +85,19 @@ class BeanConfigurationsAssetScannerTest {
 		}
 	}
 
-	internal class ABeanConfigurationNeedingTheContext(context: Context?) : BeanConfiguration() {
+	internal class ABeanConfigurationNeedingTheContext(context: Context) : BeanConfiguration() {
 		override fun getBeanDefinitions(): List<BeanDefinition<*>> {
 			return emptyList()
 		}
 	}
 
 	class AnotherBeanConfiguration : BeanConfiguration() {
+		override fun getBeanDefinitions(): List<BeanDefinition<*>> {
+			return emptyList()
+		}
+	}
+
+	object ABeanConfigurationObject : BeanConfiguration() {
 		override fun getBeanDefinitions(): List<BeanDefinition<*>> {
 			return emptyList()
 		}


### PR DESCRIPTION
- Allow to define BeanConfigurations as Kotlin objects.
- Add missing Java-API tests for BeanConfigurations as Java classes.