### PR TITLE
remove BeanReference.

### DIFF
--- a/android-beans/src/main/kotlin/rocks/frieler/android/beans/BeanDefinition.kt
+++ b/android-beans/src/main/kotlin/rocks/frieler/android/beans/BeanDefinition.kt
@@ -7,9 +7,7 @@ open class BeanDefinition<T : Any>(
 		private val name: String? = null,
 		private val type: KClass<T>,
 		private val creator: (BeansProvider) -> T
-) : BeanReference<T> {
-
-	private lateinit var bean : T
+) {
 
 	fun getName() : String? {
 		return name
@@ -24,20 +22,6 @@ open class BeanDefinition<T : Any>(
 	}
 
 	fun produceBean(dependencyProvider: BeansProvider) : T {
-		if (this::bean.isInitialized) {
-			throw IllegalStateException("the bean was already produced.")
-		}
-
-		return creator.invoke(dependencyProvider).also {
-			bean = it
-		}
-	}
-
-	override fun use() : T {
-		if (!this::bean.isInitialized) {
-			throw IllegalStateException("the bean was not produced yet.")
-		}
-
-		return bean
+		return creator.invoke(dependencyProvider)
 	}
 }

--- a/android-beans/src/main/kotlin/rocks/frieler/android/beans/BeanReference.kt
+++ b/android-beans/src/main/kotlin/rocks/frieler/android/beans/BeanReference.kt
@@ -1,5 +1,0 @@
-package rocks.frieler.android.beans
-
-interface BeanReference<T : Any> {
-	fun use() : T
-}

--- a/android-beans/src/main/kotlin/rocks/frieler/android/beans/DeclarativeBeanConfiguration.kt
+++ b/android-beans/src/main/kotlin/rocks/frieler/android/beans/DeclarativeBeanConfiguration.kt
@@ -43,12 +43,10 @@ abstract class DeclarativeBeanConfiguration : BeanConfiguration() {
 	 * with a factory-function for the [BeanDefinition]
 	 *
 	 * @param beanDefinition the [BeanDefinition]
-	 * @return a [BeanReference] for the defined bean that will be available later
 	 * @see addBeanDefinition
 	 */
-	fun <T : Any> bean(beanDefinition: BeanDefinition<T>): BeanReference<T> {
+	fun <T : Any> bean(beanDefinition: BeanDefinition<T>) {
 		addBeanDefinition(beanDefinition)
-		return beanDefinition
 	}
 
 	/**
@@ -56,12 +54,10 @@ abstract class DeclarativeBeanConfiguration : BeanConfiguration() {
 	 *
 	 * @param name the bean's name (optional)
 	 * @param definition the definition to construct the bean
-	 * @return a [BeanReference] for the defined bean that will be available later
 	 */
-	inline fun <reified T : Any> bean(name: String? = null, noinline definition: BeansProvider.() -> T): BeanReference<T> {
+	inline fun <reified T : Any> bean(name: String? = null, noinline definition: BeansProvider.() -> T) {
 		val beanDefinition = BeanDefinition(name, T::class, definition)
 		addBeanDefinition(beanDefinition)
-		return beanDefinition
 	}
 
 	/**
@@ -73,13 +69,11 @@ abstract class DeclarativeBeanConfiguration : BeanConfiguration() {
 	 * @param name the bean's name (optional)
 	 * @param type the bean's type
 	 * @param definition the definition to construct the bean
-	 * @return a [BeanReference] for the defined bean that will be available later
 	 */
 	@JvmOverloads
-	fun <T : Any> bean(name: String? = null, type: Class<T>, definition: BeansProvider.() -> T): BeanReference<T> {
+	fun <T : Any> bean(name: String? = null, type: Class<T>, definition: BeansProvider.() -> T) {
 		val beanDefinition = BeanDefinition(name, type.kotlin, definition)
 		addBeanDefinition(beanDefinition)
-		return beanDefinition
 	}
 
 	/**
@@ -91,12 +85,10 @@ abstract class DeclarativeBeanConfiguration : BeanConfiguration() {
 	 * @param name the bean's name (optional)
 	 * @param type the bean's type
 	 * @param definition the definition to construct the bean
-	 * @return a [BeanReference] for the defined bean that will be available later
 	 */
 	@JvmOverloads
-	fun <T : Any> bean(name: String? = null, type: Class<T>, definition: () -> T): BeanReference<T> {
+	fun <T : Any> bean(name: String? = null, type: Class<T>, definition: () -> T) {
 		val beanDefinition = BeanDefinition(name, type.kotlin) { definition() }
 		addBeanDefinition(beanDefinition)
-		return beanDefinition
 	}
 }

--- a/android-beans/src/test/java/rocks/frieler/android/beans/DeclarativeBeanConfigurationJavaApiTest.java
+++ b/android-beans/src/test/java/rocks/frieler/android/beans/DeclarativeBeanConfigurationJavaApiTest.java
@@ -14,7 +14,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
 import static rocks.frieler.android.beans.scopes.activity.ActivityScopedFactoryBean.activityScoped;
 import static rocks.frieler.android.beans.scopes.prototype.PrototypeScopedFactoryBean.prototype;
 import static rocks.frieler.android.beans.scopes.singleton.SingletonScopedFactoryBean.lazyInstantiated;
@@ -36,25 +35,6 @@ public class DeclarativeBeanConfigurationJavaApiTest {
         assertThat(beanDefinitions.size(), is(equalTo(2)));
         assertThat(beanDefinitions.get(0).getName(), is(nullValue()));
         assertThat(beanDefinitions.get(1).getName(), is("named_bean"));
-    }
-
-    @Test
-    public void testDeclarativeBeanConfigurationCanUseBeansDefinedEarlierInThisBeanConfiguration() {
-        BeansProvider dependencies = mock(BeansProvider.class);
-
-        DeclarativeBeanConfiguration beanConfiguration = new DeclarativeBeanConfiguration() {
-            @Override
-            public void beans() {
-                BeanReference<DeclarativeBeanConfigurationJavaApiTest> aBean = bean(DeclarativeBeanConfigurationJavaApiTest.class, DeclarativeBeanConfigurationJavaApiTest::new);
-                bean(String.class, () -> aBean.use().toString());
-            }
-        };
-
-        List<BeanDefinition<?>> beanDefinitions = beanConfiguration.getBeanDefinitions();
-
-        assertThat(beanDefinitions.size(), is(2));
-        final Object aBean = beanDefinitions.get(0).produceBean(dependencies);
-        assertThat(beanDefinitions.get(1).produceBean(dependencies), is(equalTo(aBean.toString())));
     }
 
     @Test

--- a/android-beans/src/test/kotlin/rocks/frieler/android/beans/BeanDefinitionTest.kt
+++ b/android-beans/src/test/kotlin/rocks/frieler/android/beans/BeanDefinitionTest.kt
@@ -1,11 +1,7 @@
 package rocks.frieler.android.beans
 
-import assertk.all
 import assertk.assertThat
-import assertk.assertions.hasClass
-import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFailure
 import assertk.assertions.isFalse
 import assertk.assertions.isSameAs
 import assertk.assertions.isTrue
@@ -56,38 +52,5 @@ class BeanDefinitionTest {
 
 		verify(beanCreator).invoke(dependencyProvider)
 		assertThat(bean).isSameAs(this)
-	}
-
-	@Test
-	fun `produceBean() cannot be invoked twice`() {
-		whenever(beanCreator.invoke(dependencyProvider)).thenReturn(this)
-
-		beanDefinition.produceBean(dependencyProvider)
-		assertThat {
-			beanDefinition.produceBean(dependencyProvider)
-		}.isFailure().all {
-			hasClass(IllegalStateException::class)
-			hasMessage("the bean was already produced.")
-		}
-	}
-
-	@Test
-	fun `use() cannot be invoked before the bean was produced`() {
-		assertThat {
-			beanDefinition.use()
-		}.isFailure().all {
-			hasClass(IllegalStateException::class)
-			hasMessage("the bean was not produced yet.")
-		}
-	}
-
-	@Test
-	fun `use() returns the produced bean`() {
-		whenever(beanCreator.invoke(dependencyProvider)).thenReturn(this)
-
-		val producedBean = beanDefinition.produceBean(dependencyProvider)
-		val bean = beanDefinition.use()
-
-		assertThat(bean).isSameAs(producedBean)
 	}
 }

--- a/android-beans/src/test/kotlin/rocks/frieler/android/beans/DeclarativeBeanConfigurationTest.kt
+++ b/android-beans/src/test/kotlin/rocks/frieler/android/beans/DeclarativeBeanConfigurationTest.kt
@@ -106,27 +106,4 @@ class DeclarativeBeanConfigurationTest {
 		assertThat(beanDefinitions[0].getType()).isEqualTo(Any::class)
 		assertThat(beanDefinitions[0].produceBean(dependencyProvider)).isSameAs(this)
 	}
-
-	@Test
-	fun `Defining a bean returns a BeanReference to use the bean as a dependency for further beans`() {
-		val aBeanConfiguration = object : DeclarativeBeanConfiguration() {
-			override fun beans() {
-				val beanRef = bean("bean") {
-					this@DeclarativeBeanConfigurationTest
-				}
-
-				bean("anotherBean") {
-					beanRef.use()
-				}
-			}
-		}
-
-		val beanDefinitions = aBeanConfiguration.getBeanDefinitions()
-
-		assertThat(beanDefinitions).hasSize(2)
-		assertThat(beanDefinitions[0].getName()).isEqualTo("bean")
-		assertThat(beanDefinitions[0].produceBean(dependencyProvider)).isSameAs(this)
-		assertThat(beanDefinitions[1].getName()).isEqualTo("anotherBean")
-		assertThat(beanDefinitions[1].produceBean(dependencyProvider)).isSameAs(this)
-	}
 }


### PR DESCRIPTION
It won't work properly, because BeanDefinitions are not guaranteed to be processed in definition order. Dependencies must be obtained through the BeansProvider instead.