### PR TITLE
test-coverage in sonar analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ android:
 before_install:
   - chmod +x gradlew
 
-script: ./gradlew clean testReleaseUnitTest sonarqube assembleRelease kdocJar sourcesJar
+script:
+  - . ./.travis/prepareSonarAnalysis.sh
+  - ./gradlew clean testReleaseUnitTest sonarqube assembleRelease kdocJar sourcesJar
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ android:
 before_install:
   - chmod +x gradlew
 
-script: ./gradlew clean testReleaseUnitTest assembleRelease kdocJar sourcesJar
+script: ./gradlew clean testReleaseUnitTest sonarqube assembleRelease kdocJar sourcesJar
 
 deploy:
   provider: script

--- a/.travis/prepareSonarAnalysis.sh
+++ b/.travis/prepareSonarAnalysis.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ "$TRAVIS" != "true" ]; then
+  echo "warn: looks like not running inside a travis-ci build."
+fi
+
+case "$TRAVIS_EVENT_TYPE" in
+  "push")
+    export SONAR_ANALYSIS_TYPE="branch"
+    export SONAR_BRANCH_NAME="$TRAVIS_BRANCH"
+    if [ "$TRAVIS_BRANCH" != "master" ]; then # allow to compare the current branch against master
+      git fetch --no-tags origin +refs/heads/master:refs/remotes/origin/master
+    fi
+    ;;
+  "pull_request")
+    export SONAR_ANALYSIS_TYPE="pull_request"
+    export SONAR_PULLREQUEST_KEY="$TRAVIS_PULL_REQUEST"
+    ;;
+  *)
+    echo "warn: unknown TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE"
+    ;;
+esac

--- a/android-beans/build.gradle.kts
+++ b/android-beans/build.gradle.kts
@@ -47,6 +47,7 @@ android {
 			android.libraryVariants.matching { name == "release" }.all { outputs.all { this as BaseVariantOutputImpl
 				outputFileName = outputFileName.replace("-release", "") }
 			}
+            testBuildType = this.name
 		}
     }
 }

--- a/android-beans/build.gradle.kts
+++ b/android-beans/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	id("com.android.library")
     id("kotlin-android")
     id("org.jetbrains.dokka-android")
+    id("org.gradle.jacoco")
 	id("maven-publish")
 	id("com.jfrog.bintray")
 }
@@ -74,6 +75,17 @@ val kdocJar by tasks.registering(Jar::class) {
 val sourcesJar by tasks.registering(Jar::class) {
     from(android.sourceSets["main"].java.srcDirs)
     archiveClassifier.set("sources")
+}
+
+val jacocoReport by tasks.registering(JacocoReport::class) {
+    group = "verification"
+    dependsOn(tasks.getByName("testReleaseUnitTest"))
+    classDirectories.from("$buildDir/tmp/kotlin-classes/release")
+    executionData(files("$buildDir/jacoco/testReleaseUnitTest.exec"))
+    reports {
+        xml.isEnabled = true
+        html.isEnabled = false
+    }
 }
 
 publishing {

--- a/android-beans/build.gradle.kts
+++ b/android-beans/build.gradle.kts
@@ -77,6 +77,12 @@ val sourcesJar by tasks.registering(Jar::class) {
     archiveClassifier.set("sources")
 }
 
+tasks.withType(Test::class) {
+    with(extensions.getByType(JacocoTaskExtension::class)) {
+        isIncludeNoLocationClasses = true
+        excludes = listOf("jdk.internal.*") // workaround for https://github.com/gradle/gradle/issues/5184
+    }
+}
 val jacocoReport by tasks.registering(JacocoReport::class) {
     group = "verification"
     dependsOn(tasks.getByName("testReleaseUnitTest"))

--- a/android-beans/build.gradle.kts
+++ b/android-beans/build.gradle.kts
@@ -93,6 +93,7 @@ val jacocoReport by tasks.registering(JacocoReport::class) {
         html.isEnabled = false
     }
 }
+rootProject.tasks["sonarqube"].dependsOn(jacocoReport)
 
 publishing {
     publications {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,13 @@ buildscript {
         classpath("com.android.tools.build:gradle:4.0.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
         classpath("org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18")
+        classpath("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7.1")
         classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
     }
+}
+
+plugins {
+    id("org.sonarqube") version "2.7.1"
 }
 
 allprojects {
@@ -25,5 +30,14 @@ allprojects {
 tasks {
     val clean by registering(Delete::class) {
         delete(buildDir)
+    }
+}
+
+sonarqube {
+    properties {
+        property("sonar.host.url", "https://sonarcloud.io")
+        property("sonar.organization", "christopherfrieler")
+        property("sonar.projectKey", "christopherfrieler_android-beans")
+        property("sonar.projectName", "android-beans")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.cxx.logging.warnln
+
 buildscript {
     repositories {
         google()
@@ -37,7 +39,12 @@ sonarqube {
     properties {
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.organization", "christopherfrieler")
-        property("sonar.projectKey", "christopherfrieler_android-beans")
         property("sonar.projectName", "android-beans")
+        property("sonar.projectKey", "christopherfrieler_android-beans")
+        when (val analysisType = System.getenv("SONAR_ANALYSIS_TYPE")) {
+            "branch" -> property("sonar.branch.name", System.getenv("SONAR_BRANCH_NAME"))
+            "pull_request" -> property("sonar.pullrequest.key", System.getenv("SONAR_PULLREQUEST_KEY"))
+            else -> warnln("unknown SONAR_ANALYSIS_TYPE: '%s'", analysisType)
+        }
     }
 }


### PR DESCRIPTION
To get the test-coverage into the sonar-report, we also had to change the sonar-integration. It has to be called explicitly from the travis-ci build that executes the tests and measures the coverage.