### PR TITLE
Update com.android.tools.build:gradle to 8.13.2

### DIFF
--- a/android-beans/build.gradle.kts
+++ b/android-beans/build.gradle.kts
@@ -27,7 +27,7 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    compileSdk = 34
+    compileSdk = 35
     buildToolsVersion = "36.0.0"
 
     defaultConfig {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.3.20"
-android-build-tools-gradle = "8.7.3"
+android-build-tools-gradle = "8.13.2"
 androidx-activity = "1.10.1"
 androidx-lifecycle = "2.8.7"
 android-tools-desugar_jdk_libs = "2.1.5"


### PR DESCRIPTION
Version 9 is currently not compatible with the sonar plugin.